### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1562,7 +1562,7 @@ if (typeof jQuery === 'undefined') {
     var $tip  = this.tip()
     var title = this.getTitle()
 
-    $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
+    $tip.find('.tooltip-inner').text(title)
     $tip.removeClass('fade in top bottom left right')
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/NikhilRajNR/NikhilRajNR.github.io/security/code-scanning/6](https://github.com/NikhilRajNR/NikhilRajNR.github.io/security/code-scanning/6)

The best fix is to avoid inserting untrusted tooltip title content with `.html()` unless it is sanitized first. In this snippet, the safest non-breaking approach is to always render `title` as text in `setContent()`, which neutralizes HTML metacharacters and prevents XSS from `data-original-title`.

**Change to make in `js/bootstrap.js`:**
- In `Tooltip.prototype.setContent` (around line 1565), replace the dynamic `html/text` dispatch with a direct `.text(title)` call.

This is a minimal, localized fix requiring no new imports or helper methods and eliminates the vulnerable sink in this shown code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
